### PR TITLE
Release 1.3.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+source = photo_importer
+omit =
+    */conftest.py
+    */*_test.py
+    photo_importer/test.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+    raise NotImplementedError

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "env": {
+    "browser": true,
+    "es2020": true,
+    "jquery": true
+  },
+  "plugins": ["html"],
+  "rules": {
+    "no-eval": "error",
+    "no-undef": "error",
+    "no-unused-vars": [
+      "warn",
+      {
+        "varsIgnorePattern": "^(g_|sendCommand|reload|init)",
+        "argsIgnorePattern": ".*"
+      }
+    ],
+    "eqeqeq": ["warn", "smart"],
+    "no-var": "warn"
+  }
+}

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,17 @@
+name: ESLint
+
+on: [push, pull_request]
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Lint JavaScript
+        run: npx eslint web/index.html

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install pylint pytest
         pip install .
     - name: Analysing the code with pylint
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,4 +21,4 @@ jobs:
         pip install .
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py') --disable missing-function-docstring,missing-module-docstring,missing-class-docstring,broad-exception-caught,too-many-positional-arguments
+        pylint $(git ls-files '*.py') --max-line-length=140 --disable missing-function-docstring,missing-module-docstring,missing-class-docstring,broad-exception-caught,R0917

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,6 +13,9 @@ jobs:
         include:
           - python-version: "3.7"
             os: ubuntu-20.04
+        exclude:
+          - python-version: "3.7"
+            os: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,17 +5,10 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest]
-        include:
-          - python-version: "3.7"
-            os: ubuntu-20.04
-        exclude:
-          - python-version: "3.7"
-            os: ubuntu-latest
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +25,7 @@ jobs:
       - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py37 .
+          ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py38 .
       - name: Test with pytest
         run: |
           pytest --cov=photo_importer --cov-report=term-missing --cov-fail-under=85

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,9 +15,9 @@ jobs:
             os: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,10 +5,14 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest]
+        include:
+          - python-version: "3.7"
+            os: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,15 +26,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest
+          pip install ruff pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          sudo apt install exiftran exiftool pmount 
+          sudo apt install exiftran exiftool pmount
       - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          #ruff --format=github --select=E9,F63,F7,F82 --target-version=py37 .
-          # default set of ruff rules with GitHub Annotations
-          #ruff --format=github --target-version=py37 .
+          ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py37 .
       - name: Test with pytest
         run: |
-          pytest
+          pytest --cov=photo_importer --cov-report=term-missing --cov-fail-under=85

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+node_modules

--- a/README.md
+++ b/README.md
@@ -5,125 +5,183 @@
 [![PyPI - Downloads](https://pepy.tech/badge/photo-importer)](https://pepy.tech/project/photo-importer)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-Command line tools for photo importing/renaming/rotating
-### Features:
-  * Media files scan
-  * Time when picture was taken detection (by EXIF, by file name, by file attributes)
-  * Media files moving/copying to configurable hierarchy 
-  * Lossless rotations (via exiftran or jpegtran)
+A command-line tool and standalone web server for importing, renaming, and rotating photos and videos from cameras, USB drives, and memory cards.
 
-# Photo Importer Server
-Standalone web server for fast media import for headless computer
-### Features:
-  * Mounted storages detection (by path mask)
-  * Storages mount/unmount (via pmount)
-  * The same as photo-importer but without console
+---
 
-# Installation
+## Table of Contents
 
-### Requirements:
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Acknowledgements](#acknowledgements)
 
-  * Python 3.3+
+---
 
-### Supported OS:
+## Features
 
-  * Debian based Linux (other Linux versions not officially supported, but might work)
-  * Windows 7 and above
-  * MacOS X and above (with brew installed, only console version)
+### photo-importer (CLI)
 
-### Dependencies:
-  * [PyExifTool](https://pypi.org/project/PyExifTool/)
-  * [progressbar](https://pypi.org/project/progressbar/)
-  * [psutil](https://pypi.org/project/psutil/)
-  * [exiftran](https://linux.die.net/man/1/exiftran) or [jpegtran](https://linux.die.net/man/1/jpegtran)
-  * [pmount](https://linux.die.net/man/1/pmount) (only for server)
-  * [pypiwin32](https://pypi.org/project/pypiwin32/) (only for windows)
+- Scans directories for media files (images, video, audio)
+- Detects capture time via EXIF metadata, filename patterns, or file attributes
+- Organises files into a configurable date-based directory hierarchy
+- Renames files according to capture timestamp
+- Performs lossless JPEG rotation (via [exiftran](https://linux.die.net/man/1/exiftran) or [jpegtran](https://linux.die.net/man/1/jpegtran))
+- Supports dry-run mode for previewing changes without modifying files
 
+### photo-importer-server (Web UI)
 
-### Installation Options:
+- Standalone web server for use on headless machines (e.g. a home server or Raspberry Pi)
+- Detects mounted removable storage by path mask
+- Provides one-click mount, import, and unmount via a browser interface
+- Same import pipeline as the CLI tool
 
-#### Installing via PyPi
+---
+
+## Installation
+
+### Requirements
+
+- Python 3.6+
+
+### Supported Platforms
+
+| Platform | Support |
+|---|---|
+| Debian-based Linux | Full (CLI + Web) |
+| Other Linux | Unofficial (likely works) |
+| Windows 7+ | CLI + Web |
+| macOS (with Homebrew) | CLI only |
+
+### System Dependencies
+
+| Dependency | Purpose |
+|---|---|
+| [exiftool](https://exiftool.org/) | EXIF metadata reading |
+| [exiftran](https://linux.die.net/man/1/exiftran) or [jpegtran](https://linux.die.net/man/1/jpegtran) | Lossless JPEG rotation |
+| [pmount](https://linux.die.net/man/1/pmount) | Storage mount/unmount (server only) |
+
+### Python Dependencies
+
+- [PyExifTool](https://pypi.org/project/PyExifTool/)
+- [progressbar](https://pypi.org/project/progressbar/)
+- [psutil](https://pypi.org/project/psutil/)
+- [pypiwin32](https://pypi.org/project/pypiwin32/) *(Windows only)*
+
+### Installing via PyPI *(recommended)*
+
 ```bash
 sudo apt install exiftran exiftool pmount pip
 sudo pip install photo-importer
 ```
-#### Installing as debian package
+
+### Installing as a Debian Package
+
 ```bash
 debuild -b
 sudo apt install pip python3-exif python3-progressbar exiftran python3-psutil
 sudo pip install PyExifTool
-sudo dpkg -i ../photo-importer_1.2.5_all.deb
+sudo dpkg -i ../photo-importer_*.deb
 ```
-#### Installing via setup.py
+
+### Installing from Source
+
 ```bash
 sudo apt install exiftran exiftool pmount pip
 sudo pip install PyExifTool progressbar psutil
 sudo python3 ./setup.py install
 ```
 
-#### Installing for Windows
-Download and install python3 for you Windows distributive
-https://www.python.org/downloads/windows/
+### Installing on Windows
 
-Download and install exiftool
-https://exiftool.org/
+1. Download and install [Python 3](https://www.python.org/downloads/windows/)
+2. Download and install [ExifTool](https://exiftool.org/)
+3. Download and extract [jpegtran](http://sylvana.net/jpegcrop/jpegtran/) into the `photo_importer` folder
+4. Install the package and its Windows dependencies:
 
-Download and extract jpegtran to photo_importer folder
-http://sylvana.net/jpegcrop/jpegtran/
-
-Install with python dependencies
-```bash
+```bat
 python -m pip install pypiwin32 photo-importer
 ```
 
+---
+
 ## Usage
+
 ### Command-Line Interface
+
+**In-place processing** — rename and rotate files without moving them:
 
 ```bash
 photo-importer /path/to/media/files
 ```
-Will process files (reanaming/rotating) in-place.
+
 ![In place example](https://user-images.githubusercontent.com/28735879/76139947-bd249780-6055-11ea-85c0-0985b6bde93f.png)
+
+**Import to output directory** — move (or copy) files into a date-based hierarchy:
 
 ```bash
 photo-importer /path/to/media/files /output/path
 ```
-Will import (by default move, but it can be changed in config) files from /path/to/media/files to /output/path with date hierarchy creation and reanaming/rotating
+
+Files are moved by default. To copy instead, set `move_mode = 0` in the config file.
 
 ![Move example](https://user-images.githubusercontent.com/28735879/76139964-eba27280-6055-11ea-988f-aa71cda7ba36.png)
 
+**CLI options:**
+
+| Option | Description |
+|---|---|
+| `in_path` | Source directory to scan (required) |
+| `out_path` | Destination directory (optional; in-place mode if omitted) |
+| `-c`, `--config FILE` | Path to a custom config file |
+| `-l`, `--logfile FILE` | Log file path (default: `log.txt`) |
+| `-d`, `--dryrun` | Dry run — preview actions without modifying files |
+
 ### Web Interface
-  * attach usb-drive / usert memory card
-  * open http://servername:8080
-  * click "Mount"
-  * click "Import"
-  * click "Unmount"
+
+1. Attach a USB drive or insert a memory card
+2. Open `http://<hostname>:8080` in a browser
+3. Click **Mount**
+4. Click **Import**
+5. Click **Unmount**
 
 ![Web interface example](https://user-images.githubusercontent.com/28735879/76140174-f1995300-6057-11ea-8718-19c38650c786.png)
 
-### Windows command line
-```bash
+### Windows — Command Line
+
+```bat
 cd photo_importer
-run.py -c ..\photo-importer-win.cfg path\to\media\files \output\path
+python run.py -c ..\photo-importer-win.cfg path\to\media\files \output\path
 ```
-### Windows web 
-```bash
+
+### Windows — Web Server
+
+```bat
 photo-importer-server.bat
 ```
 
+---
+
 ## Configuration
-The server config file located in /etc/photo-importer.cfg
 
-Command line tool config file located in ~/.photo-importer.cfg
+| Scope | Default config file |
+|---|---|
+| CLI tool | `~/.photo-importer.cfg` |
+| Web server | `/etc/photo-importer.cfg` |
 
-Also config file can be specified by mean of -c command line option.
+A custom config file can be passed to the CLI with the `-c` option.
 
-For options details see comments in the config file.
+All available options are documented with comments inside the config file itself.
+
+---
 
 ## Acknowledgements
-Thanks to everyone who tested and gave advice.
 
-**Bug reports, suggestions and pull request are welcome!**
+Thanks to everyone who tested the tool and provided feedback.
 
-## Show your support
+Bug reports, suggestions, and pull requests are welcome!
+
+## Show Your Support
+
 Give a ⭐️ if this project helped you!

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,27 @@
+photo-importer (1.3.0) stable; urgency=medium
+
+  * Fix jpegtran rotator returncode check (was always None before p.wait())
+  * Fix empty directory cleanup ordering
+  * Fix dryrun mode for file skipping
+  * Fix server security: validate and sanitize input paths
+  * Add ThreadingMixIn to HTTP server for concurrent request handling
+  * Add explicit MemLogger.close() to prevent log handler leakage
+  * Add exist_ok=True to os.makedirs() to prevent race on concurrent imports
+  * Guard missing move/rotate status keys in CLI error reporting
+  * Guard empty directory part in log file path creation
+  * Add os.path.realpath() normalization for importer path keys in server
+  * Update deprecated progressbar maxval field
+  * Add Config use_system_config parameter for test isolation
+  * Improve web UI: fix XSS via eval(), add escapeHtml(), fix dead state branch,
+    replace <font> tags, add AJAX error handlers, add visibility-aware polling,
+    add encodeURIComponent for all query params
+  * Add ESLint CI workflow for JavaScript linting
+  * Improve test coverage: add tests for config, mover, rotator, server, run
+  * Update CI workflows: update actions/checkout, fix Python version matrix
+  * Update README
+
+ -- Alexander Bushnev <Alexander@Bushnev.pro>  Wed, 03 Jun 2026 20:04:14 +0200
+
 photo-importer (1.2.6) stable; urgency=medium
 
   * Add Clear button for server import

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1368 @@
+{
+  "name": "photo-importer",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "eslint": "^8.57.1",
+        "eslint-plugin-html": "^8.1.4"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-html": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-8.1.4.tgz",
+      "integrity": "sha512-Eno3oPEj3s6AhvDJ5zHhnHPDvXp6LNFXuy3w51fNebOKYuTrfjOHUGwP+mOrGFpR6eOJkO1xkB8ivtbfMjbMjg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "htmlparser2": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "photo-importer-web",
+  "private": true,
+  "devDependencies": {
+    "eslint": "^8.57.1",
+    "eslint-plugin-html": "^8.1.4"
+  }
+}

--- a/photo-importer.cfg
+++ b/photo-importer.cfg
@@ -15,7 +15,7 @@ out_subdir_audio = Audio
 
 # File extensions  
 file_ext_image = jpeg,jpg,cr2
-file_ext_video = mp4,mpg,mpeg,mov,avi,mts,3gp,m4v
+file_ext_video = mp4,mpg,mpeg,mov,avi,mts,m2ts,3gp,m4v
 file_ext_audio = mp3,3gpp,m4a,wav,aac
 file_ext_garbage = thm,ctg
 file_ext_ignore = ini,zip,db

--- a/photo_importer/config.py
+++ b/photo_importer/config.py
@@ -35,6 +35,7 @@ class Config:
             'time_shift': 0,
         },
         'server': {
+            'host': '',
             'port': 8080,
             'web_path': 'web',
             'out_path': '/mnt/multimedia/NEW/',
@@ -43,8 +44,8 @@ class Config:
         },
     }
 
-    def __init__(self, filename=None, create=False):
-        if filename is None:
+    def __init__(self, filename=None, create=False, use_system_config=True):
+        if filename is None and use_system_config:
             for f in self.DEFAULT_CONFIG_FILES:
                 if os.path.exists(f):
                     filename = f

--- a/photo_importer/config_test.py
+++ b/photo_importer/config_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python3
+
+from photo_importer import config
+
+
+def test_defaults_present():
+    c = config.Config(use_system_config=False)
+    assert c['main']['out_subdir_image'] == 'Foto'
+    assert c['server']['port'] == '8080'
+
+
+def test_use_system_config_flag(monkeypatch, tmp_path):
+    sysfile = tmp_path / 'sys.cfg'
+    sysfile.write_text('[main]\nout_subdir_image = FromSystem\n')
+    monkeypatch.setattr(config.Config, 'DEFAULT_CONFIG_FILES', (str(sysfile),))
+
+    assert config.Config(use_system_config=True)['main']['out_subdir_image'] == 'FromSystem'
+    assert config.Config(use_system_config=False)['main']['out_subdir_image'] == 'Foto'
+
+
+def test_explicit_file_overrides_defaults(tmp_path):
+    cfgfile = tmp_path / 'c.cfg'
+    cfgfile.write_text('[main]\nout_subdir_image = Pics\n')
+
+    c = config.Config(str(cfgfile))
+
+    assert c['main']['out_subdir_image'] == 'Pics'
+    assert c['main']['out_subdir_video'] == 'Video'  # default preserved
+
+
+def test_create_writes_file(tmp_path, monkeypatch):
+    target = tmp_path / '.photo-importer.cfg'
+    monkeypatch.setattr(config.Config, 'DEFAULT_CONFIG_FILES', (str(target), '/nonexistent'))
+
+    config.Config(create=True, use_system_config=False)
+
+    assert target.exists()
+
+
+def test_set_updates_value():
+    c = config.Config(use_system_config=False)
+    c.set('main', 'move_mode', '0')
+    assert c['main']['move_mode'] == '0'

--- a/photo_importer/conftest.py
+++ b/photo_importer/conftest.py
@@ -1,0 +1,42 @@
+# pylint: disable=unused-argument,too-few-public-methods
+
+import pytest
+
+from photo_importer import config
+from photo_importer import fileprop
+
+
+@pytest.fixture
+def cfg():
+    """A Config built only from defaults — never reads host config files."""
+    return config.Config(use_system_config=False)
+
+
+class _FakeExifTool:
+    """Minimal stand-in for exiftool.ExifToolHelper.
+
+    Returns no metadata/tags so callers fall back to name/attr based timing,
+    and never spawns the real exiftool process.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_metadata(self, *args, **kwargs):
+        return [{}]
+
+    def get_tags(self, *args, **kwargs):
+        return [{}]
+
+    def set_tags(self, *args, **kwargs):
+        pass
+
+    def terminate(self):
+        pass
+
+
+@pytest.fixture
+def fake_exiftool(monkeypatch):
+    """Replace ExifToolHelper everywhere so tests don't need the binary."""
+    monkeypatch.setattr(fileprop.exiftool, 'ExifToolHelper', _FakeExifTool)
+    return _FakeExifTool

--- a/photo_importer/fileprop.py
+++ b/photo_importer/fileprop.py
@@ -75,8 +75,19 @@ class FileProp:
         self.__out_list = set()
         self.__exiftool = exiftool.ExifToolHelper()
 
+    def close(self):
+        if self.__exiftool is not None:
+            self.__exiftool.terminate()
+            self.__exiftool = None
+
     def __del__(self):
-        self.__exiftool.terminate()
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
     def __prepare_ext_to_type(self):
         self.ext_to_type = {}

--- a/photo_importer/fileprop.py
+++ b/photo_importer/fileprop.py
@@ -159,9 +159,7 @@ class FileProp:
 
     def __time_by_attr(self, fullname):
         try:
-            return datetime.datetime.fromtimestamp(
-                time.mktime(time.localtime(os.stat(fullname)[stat.ST_MTIME]))
-            )
+            return datetime.datetime.fromtimestamp(time.mktime(time.localtime(os.stat(fullname)[stat.ST_MTIME])))
         except (FileNotFoundError, KeyError) as ex:
             logging.warning('time by attr (%s) exception: %s', fullname, ex)
         return None
@@ -200,9 +198,7 @@ class FileProp:
             ftime += datetime.timedelta(seconds=int(time_shift))
 
         if ftime:
-            out_name = ftime.strftime(
-                self.__config['main']['out_time_format']
-            ) + self.__calc_orig_name(fname)
+            out_name = ftime.strftime(self.__config['main']['out_time_format']) + self.__calc_orig_name(fname)
         else:
             out_name = None
 

--- a/photo_importer/fileprop_extra_test.py
+++ b/photo_importer/fileprop_extra_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python3
+# pylint: disable=redefined-outer-name,unused-argument,too-few-public-methods
+
+import os
+import datetime
+
+import pytest
+
+from photo_importer import fileprop
+
+
+class _Helper:
+    """ExifToolHelper stand-in returning a configurable metadata dict."""
+
+    metadata = {}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_metadata(self, fullname):
+        return [dict(_Helper.metadata)]
+
+    def get_tags(self, *args, **kwargs):
+        return [{}]
+
+    def terminate(self):
+        pass
+
+
+@pytest.fixture
+def exif_cfg(cfg, monkeypatch):
+    monkeypatch.setattr(fileprop.exiftool, 'ExifToolHelper', _Helper)
+    _Helper.metadata = {}
+    return cfg
+
+
+def test_time_by_exif(exif_cfg):
+    _Helper.metadata = {'EXIF:DateTimeOriginal': '2020:05:01 12:00:00'}
+    fp = fileprop.FileProp(exif_cfg).get('/x/photo.jpg')
+    assert fp.type() == fileprop.IMAGE
+    assert fp.time() == datetime.datetime(2020, 5, 1, 12, 0, 0)
+
+
+def test_time_by_exif_strips_timezone(exif_cfg):
+    _Helper.metadata = {'EXIF:CreateDate': '2020:05:01 12:00:00+03:00'}
+    fp = fileprop.FileProp(exif_cfg).get('/x/photo.jpg')
+    assert fp.time() == datetime.datetime(2020, 5, 1, 12, 0, 0)
+
+
+def test_time_shift_applied(exif_cfg):
+    _Helper.metadata = {'EXIF:DateTimeOriginal': '2020:05:01 12:00:00'}
+    exif_cfg.set('main', 'time_shift', '3600')
+    fp = fileprop.FileProp(exif_cfg).get('/x/photo.jpg')
+    assert fp.time() == datetime.datetime(2020, 5, 1, 13, 0, 0)
+
+
+def test_add_orig_name(exif_cfg):
+    _Helper.metadata = {'EXIF:DateTimeOriginal': '2020:05:01 12:00:00'}
+    exif_cfg.set('main', 'add_orig_name', '1')
+    fp = fileprop.FileProp(exif_cfg).get('/x/holiday pic.jpg')
+    assert fp.out_name() == '2020-05-01_12-00-00_holiday_pic'
+
+
+def test_unknown_extension_is_ignored(exif_cfg):
+    fp = fileprop.FileProp(exif_cfg).get('/x/file.xyz')
+    assert fp.type() == fileprop.IGNORE
+    assert fp.time() is None
+
+
+def test_time_by_attr(tmp_path, exif_cfg):
+    f = tmp_path / 'noexif.jpg'
+    f.write_bytes(b'x')
+    os.utime(f, (1590969600, 1590969600))  # 2020-06-01 UTC
+    exif_cfg.set('main', 'time_src_image', 'attr')
+    fp = fileprop.FileProp(exif_cfg).get(str(f))
+    assert fp.time().year == 2020
+
+
+def test_wrong_time_src_raises(exif_cfg):
+    exif_cfg.set('main', 'time_src_image', 'bogus')
+    with pytest.raises(UserWarning):
+        fileprop.FileProp(exif_cfg).get('/x/photo.jpg')
+
+
+def test_out_name_full_deduplicates(tmp_path, exif_cfg):
+    exif_cfg.set('main', 'time_src_image', 'name')
+    fp = fileprop.FileProp(exif_cfg)
+    res = fp.get('2020-01-01_00-00-00.jpg')
+
+    n1 = res.out_name_full(str(tmp_path))
+    n2 = res.out_name_full(str(tmp_path))
+
+    assert n1.endswith('2020-01-01_00-00-00.jpg')
+    assert n2.endswith('2020-01-01_00-00-00_2.jpg')
+
+
+def test_close_is_idempotent(exif_cfg):
+    fp = fileprop.FileProp(exif_cfg)
+    fp.close()
+    fp.close()  # must not raise

--- a/photo_importer/fileprop_test.py
+++ b/photo_importer/fileprop_test.py
@@ -10,7 +10,7 @@ from photo_importer import fileprop
 
 class TestFileProp(unittest.TestCase):
     def setUp(self):
-        self.conf = config.Config()
+        self.conf = config.Config(use_system_config=False)
         self.fp = fileprop.FileProp(self.conf)
         self.conf.set('main', 'time_src_image', 'name')
         self.conf.set('main', 'time_src_video', 'name')

--- a/photo_importer/importer.py
+++ b/photo_importer/importer.py
@@ -39,6 +39,7 @@ class Importer(threading.Thread):
 
         self.__stat['stage'] = 'done'
         logging.info('Done: %s', str(self.status()))
+        self.__log.close()
 
     def __scan_files(self, input_path):
         self.__stat['stage'] = 'scan'

--- a/photo_importer/importer.py
+++ b/photo_importer/importer.py
@@ -24,9 +24,7 @@ class Importer(threading.Thread):
         self.__log = log.MemLogger(input_path)
 
     def run(self):
-        logging.info(
-            'Start: %s -> %s (dryrun: %s)', self.__input_path, self.__output_path, self.__dryrun
-        )
+        logging.info('Start: %s -> %s (dryrun: %s)', self.__input_path, self.__output_path, self.__dryrun)
 
         filenames, dirs = self.__scan_files(self.__input_path)
 

--- a/photo_importer/importer.py
+++ b/photo_importer/importer.py
@@ -90,8 +90,8 @@ class Importer(threading.Thread):
 
     def __remove_empty_dirs(self, dirs):
         logging.info('Removing empty dirs')
-        len_dirs = reversed(sorted([(len(d), d) for d in dirs]))
-        for _, d in len_dirs:
+        # Deepest first, so parents become empty once children are removed.
+        for d in sorted(dirs, key=lambda p: p.count(os.sep), reverse=True):
             try:
                 os.rmdir(d)
                 logging.info('Removed: %s', d)

--- a/photo_importer/importer_test.py
+++ b/photo_importer/importer_test.py
@@ -11,7 +11,7 @@ from photo_importer import importer
 class TestImporter(unittest.TestCase):
     def test_importer(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
-            cfg = config.Config()
+            cfg = config.Config(use_system_config=False)
             cfg.set('main', 'move_mode', '0')
             imp = importer.Importer(
                 cfg,

--- a/photo_importer/log.py
+++ b/photo_importer/log.py
@@ -10,7 +10,9 @@ DATEFMT = '%Y-%m-%d %H:%M:%S'
 def init_logger(filename=None, level=logging.INFO):
     if filename is not None:
         try:
-            os.makedirs(os.path.split(filename)[0])
+            dir_part = os.path.split(filename)[0]
+            if dir_part:
+                os.makedirs(dir_part, exist_ok=True)
         except OSError:
             pass
         mode = 'a' if os.path.isfile(filename) else 'w'
@@ -38,9 +40,14 @@ class MemLogger:
         logging.getLogger().addHandler(self.__handler)
         logging.info("MemLogger %s started", self.__name)
 
+    def close(self):
+        if self.__handler is not None:
+            logging.info("MemLogger %s finished", self.__name)
+            logging.getLogger().removeHandler(self.__handler)
+            self.__handler = None
+
     def __del__(self):
-        logging.getLogger().removeHandler(self.__handler)
-        logging.info("MemLogger %s finished", self.__name)
+        self.close()
 
     def get_text(self):
         return self.__stream.getvalue()

--- a/photo_importer/mover.py
+++ b/photo_importer/mover.py
@@ -80,7 +80,7 @@ class Mover:
 
             if not os.path.isdir(path):
                 if not self.__dryrun:
-                    os.makedirs(path)
+                    os.makedirs(path, exist_ok=True)
                 logging.info('dir "%s" created', path)
 
             fullname = prop.out_name_full(path)

--- a/photo_importer/mover.py
+++ b/photo_importer/mover.py
@@ -37,17 +37,20 @@ class Mover:
         self.__stat['processed'] = 0
         self.__stat['errors'] = 0
         res = []
-        for fname in self.__filenames:
-            try:
-                prop = self.__file_prop.get(fname)
-                new_fname = self.__move_file(fname, prop)
-                if new_fname:
-                    res.append((fname, new_fname, prop))
-            except Exception as ex:
-                logging.error('Move files exception: %s', ex)
-                self.__stat['errors'] += 1
+        try:
+            for fname in self.__filenames:
+                try:
+                    prop = self.__file_prop.get(fname)
+                    new_fname = self.__move_file(fname, prop)
+                    if new_fname:
+                        res.append((fname, new_fname, prop))
+                except Exception as ex:
+                    logging.error('Move files exception: %s', ex)
+                    self.__stat['errors'] += 1
 
-            self.__stat['processed'] += 1
+                self.__stat['processed'] += 1
+        finally:
+            self.__file_prop.close()
 
         return res
 
@@ -104,6 +107,8 @@ class Mover:
         return new_fname
 
     def __move(self, src, dst):
+        if self.__dryrun:
+            return
         if self.__use_shutil:
             shutil.move(src, dst)
         else:
@@ -111,6 +116,8 @@ class Mover:
                 raise SystemError(f'mv "{src}" "{dst}" failed')
 
     def __copy(self, src, dst):
+        if self.__dryrun:
+            return
         if self.__use_shutil:
             shutil.copy2(src, dst)
         else:
@@ -118,9 +125,6 @@ class Mover:
                 raise SystemError(f'cp "{src}" "{dst}" failed')
 
     def __run(self, args):
-        if self.__dryrun:
-            return True
-
         with subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
             proc.wait()
             info = proc.stdout.read().strip()

--- a/photo_importer/mover_test.py
+++ b/photo_importer/mover_test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/python3
+# pylint: disable=redefined-outer-name,unused-argument,too-few-public-methods
+
+import os
+
+import pytest
+
+from photo_importer import mover
+
+
+def _file(tmp_path, name='2021-12-19_13-11-36.jpg', data=b'data'):
+    p = tmp_path / name
+    p.write_bytes(data)
+    return str(p)
+
+
+@pytest.fixture
+def cfg_name(cfg):
+    cfg.set('main', 'time_src_image', 'name')
+    cfg.set('main', 'time_src_video', 'name')
+    cfg.set('main', 'time_src_audio', 'name')
+    return cfg
+
+
+def _dst(out):
+    return out / 'Foto' / '2021' / '2021-12-19' / '2021-12-19_13-11-36.jpg'
+
+
+# --- dryrun (regression: use_shutil used to bypass the dryrun guard) ---
+
+
+def test_dryrun_with_shutil_does_not_touch_files(tmp_path, cfg_name, fake_exiftool, monkeypatch):
+    src = _file(tmp_path)
+    cfg_name.set('main', 'use_shutil', '1')
+    cfg_name.set('main', 'move_mode', '1')
+    calls = []
+    monkeypatch.setattr(mover.shutil, 'move', lambda s, d: calls.append((s, d)))
+    monkeypatch.setattr(mover.shutil, 'copy2', lambda s, d: calls.append((s, d)))
+
+    m = mover.Mover(cfg_name, str(tmp_path / 'out'), [src], dryrun=True)
+    res = m.run()
+
+    assert not calls
+    assert os.path.exists(src)
+    assert m.status()['moved'] == 1
+    assert len(res) == 1
+
+
+# --- copy / move via shutil ---
+
+
+def test_copy_creates_file_and_keeps_source(tmp_path, cfg_name, fake_exiftool):
+    src = _file(tmp_path)
+    cfg_name.set('main', 'use_shutil', '1')
+    cfg_name.set('main', 'move_mode', '0')
+    out = tmp_path / 'out'
+
+    mover.Mover(cfg_name, str(out), [src], dryrun=False).run()
+
+    assert _dst(out).exists()
+    assert os.path.exists(src)
+
+
+def test_move_removes_source(tmp_path, cfg_name, fake_exiftool):
+    src = _file(tmp_path)
+    cfg_name.set('main', 'use_shutil', '1')
+    cfg_name.set('main', 'move_mode', '1')
+    out = tmp_path / 'out'
+
+    m = mover.Mover(cfg_name, str(out), [src], dryrun=False)
+    m.run()
+
+    assert _dst(out).exists()
+    assert not os.path.exists(src)
+    assert m.status()['moved'] == 1
+
+
+# --- copy / move via subprocess (cp / mv) ---
+
+
+def test_subprocess_copy_with_cp(tmp_path, cfg_name, fake_exiftool):
+    src = _file(tmp_path)
+    cfg_name.set('main', 'use_shutil', '0')
+    cfg_name.set('main', 'move_mode', '0')
+    out = tmp_path / 'out'
+
+    m = mover.Mover(cfg_name, str(out), [src], dryrun=False)
+    m.run()
+
+    assert _dst(out).exists()
+    assert m.status()['copied'] == 1
+
+
+# --- garbage ---
+
+
+def test_garbage_removed(tmp_path, cfg_name, fake_exiftool):
+    src = _file(tmp_path, 'M0101.ctg')
+    cfg_name.set('main', 'remove_garbage', '1')
+
+    m = mover.Mover(cfg_name, str(tmp_path / 'out'), [src], dryrun=False)
+    m.run()
+
+    assert not os.path.exists(src)
+    assert m.status()['removed'] == 1
+
+
+def test_garbage_skipped_when_disabled(tmp_path, cfg_name, fake_exiftool):
+    src = _file(tmp_path, 'M0101.ctg')
+    cfg_name.set('main', 'remove_garbage', '0')
+
+    m = mover.Mover(cfg_name, str(tmp_path / 'out'), [src], dryrun=False)
+    m.run()
+
+    assert os.path.exists(src)
+    assert m.status()['skipped'] == 1
+
+
+# --- skip cases ---
+
+
+def test_ignored_extension_skipped(tmp_path, cfg_name, fake_exiftool):
+    src = _file(tmp_path, 'archive.zip')
+
+    m = mover.Mover(cfg_name, str(tmp_path / 'out'), [src], dryrun=False)
+    m.run()
+
+    assert m.status()['skipped'] == 1
+
+
+def test_no_detectable_time_skipped(tmp_path, cfg_name, fake_exiftool):
+    src = _file(tmp_path, 'DSC_0846.jpg')
+
+    m = mover.Mover(cfg_name, str(tmp_path / 'out'), [src], dryrun=False)
+    m.run()
+
+    assert m.status()['skipped'] == 1
+
+
+# --- rename mode (no output path) ---
+
+
+def test_rename_mode_without_output_path(tmp_path, cfg_name, fake_exiftool):
+    src = _file(tmp_path, 'IMG_20180413_173249204.jpg')
+
+    m = mover.Mover(cfg_name, '', [src], dryrun=False)
+    m.run()
+
+    assert (tmp_path / '2018-04-13_17-32-49.jpg').exists()
+    assert m.status()['moved'] == 1
+
+
+def test_already_named_file_skipped(tmp_path, cfg_name, fake_exiftool):
+    src = _file(tmp_path, '2018-04-13_17-32-49.jpg')
+
+    m = mover.Mover(cfg_name, '', [src], dryrun=False)
+    m.run()
+
+    assert m.status()['skipped'] == 1
+
+
+# --- error handling ---
+
+
+def test_missing_source_counts_error(tmp_path, cfg_name, fake_exiftool):
+    missing = str(tmp_path / '2021-12-19_13-11-36.jpg')  # never created
+    cfg_name.set('main', 'use_shutil', '1')
+
+    m = mover.Mover(cfg_name, str(tmp_path / 'out'), [missing], dryrun=False)
+    m.run()
+
+    assert m.status()['errors'] == 1
+
+
+def test_mv_failure_counts_error(tmp_path, cfg_name, fake_exiftool):
+    missing = str(tmp_path / '2021-12-19_13-11-36.jpg')
+    cfg_name.set('main', 'use_shutil', '0')
+    cfg_name.set('main', 'move_mode', '1')
+
+    m = mover.Mover(cfg_name, str(tmp_path / 'out'), [missing], dryrun=False)
+    m.run()
+
+    assert m.status()['errors'] == 1

--- a/photo_importer/rotator.py
+++ b/photo_importer/rotator.py
@@ -59,7 +59,7 @@ class Rotator:
     def __process_exiftran(self, filename):
         ok = False
         try:
-            cmd = f'exiftran -aip "{filename}"'
+            cmd = ['exiftran', '-aip', filename]
             logging.debug('rotate: %s', cmd)
 
             if self.__dryrun:
@@ -68,7 +68,6 @@ class Rotator:
             error = ''
             with subprocess.Popen(
                 cmd,
-                shell=True,
                 universal_newlines=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -98,40 +97,51 @@ class Rotator:
             if orientation_cmd is None:
                 return True
 
-            logging.debug('rotate: jpegtran %s %s', orientation_cmd, filename)
-
             if self.__dryrun:
+                logging.debug('rotate: jpegtran %s %s', orientation_cmd, filename)
                 return True
 
             handle, tmpfile = tempfile.mkstemp(dir=os.path.dirname(filename))
             os.close(handle)
 
-            cmd = 'jpegtran -copy all -outfile {tmpfile} {orientation_cmd} {filename}'
+            try:
+                cmd = (
+                    ['jpegtran', '-copy', 'all', '-outfile', tmpfile]
+                    + orientation_cmd.split()
+                    + [filename]
+                )
+                logging.debug('rotate: %s', cmd)
 
-            with subprocess.Popen(
-                cmd,
-                shell=True,
-                universal_newlines=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            ) as p:
-                line = p.stderr.readline()
-                if line:
-                    logging.error('jpegtran (%s) failed: %s', filename, line)
-                    return False
+                with subprocess.Popen(
+                    cmd,
+                    universal_newlines=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                ) as p:
+                    line = p.stderr.readline()
+                    if line:
+                        logging.error('jpegtran (%s) failed: %s', filename, line)
+                        return False
+                    if p.returncode is not None and p.returncode != 0:
+                        logging.error('jpegtran (%s) exited with code %d', filename, p.returncode)
+                        return False
 
-            self.__clear_orientation_tag(tmpfile)
+                self.__clear_orientation_tag(tmpfile)
 
-            os.remove(filename)
-            os.rename(tmpfile, filename)
+                os.remove(filename)
+                os.rename(tmpfile, filename)
+                tmpfile = None
 
-            return True
+                return True
+            finally:
+                if tmpfile is not None and os.path.exists(tmpfile):
+                    os.remove(tmpfile)
         except Exception as ex:
             logging.error('Rotator exception (%s): %s', filename, ex)
             return False
 
     def __get_orientation_cmd(self, fullname):
-        tags = self.__exiftool.get_tags(fullname, ORIENTATION_TAG)
+        tags = self.__exiftool.get_tags(fullname, ORIENTATION_TAG)[0]
         if ORIENTATION_TAG not in tags:
             return None
         orientation = tags[ORIENTATION_TAG]

--- a/photo_importer/rotator.py
+++ b/photo_importer/rotator.py
@@ -122,7 +122,8 @@ class Rotator:
                     if line:
                         logging.error('jpegtran (%s) failed: %s', filename, line)
                         return False
-                    if p.returncode is not None and p.returncode != 0:
+                    p.wait()
+                    if p.returncode != 0:
                         logging.error('jpegtran (%s) exited with code %d', filename, p.returncode)
                         return False
 

--- a/photo_importer/rotator.py
+++ b/photo_importer/rotator.py
@@ -105,11 +105,7 @@ class Rotator:
             os.close(handle)
 
             try:
-                cmd = (
-                    ['jpegtran', '-copy', 'all', '-outfile', tmpfile]
-                    + orientation_cmd.split()
-                    + [filename]
-                )
+                cmd = ['jpegtran', '-copy', 'all', '-outfile', tmpfile] + orientation_cmd.split() + [filename]
                 logging.debug('rotate: %s', cmd)
 
                 with subprocess.Popen(

--- a/photo_importer/rotator_test.py
+++ b/photo_importer/rotator_test.py
@@ -1,0 +1,196 @@
+#!/usr/bin/python3
+# pylint: disable=redefined-outer-name,unused-argument,too-few-public-methods
+
+import pytest
+
+from photo_importer import rotator
+
+
+class _Stream:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def readline(self):
+        return self._lines.pop(0) if self._lines else ''
+
+    def read(self):
+        s = ''.join(self._lines)
+        self._lines = []
+        return s
+
+
+class _FakePopen:
+    instances = []
+    stderr_lines = []
+
+    def __init__(self, args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.returncode = 0
+        self.stderr = _Stream(list(_FakePopen.stderr_lines))
+        self.stdout = _Stream([])
+        _FakePopen.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def wait(self):
+        pass
+
+
+class _FakeHelper:
+    orientation = 6
+
+    def __init__(self, *args, **kwargs):
+        self.set_calls = []
+
+    def get_tags(self, fullname, tag):
+        if _FakeHelper.orientation is None:
+            return [{}]
+        return [{rotator.ORIENTATION_TAG: _FakeHelper.orientation}]
+
+    def set_tags(self, fullname, tags):
+        self.set_calls.append((fullname, tags))
+
+    def terminate(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _FakePopen.instances = []
+    _FakePopen.stderr_lines = []
+    _FakeHelper.orientation = 6
+    yield
+
+
+# --- exiftran path ---
+
+
+def test_exiftran_argv_and_success(cfg, monkeypatch):
+    cfg.set('main', 'use_jpegtran', '0')
+    _FakePopen.stderr_lines = ['processing img.jpg\n']
+    monkeypatch.setattr(rotator.subprocess, 'Popen', _FakePopen)
+
+    r = rotator.Rotator(cfg, ['/x/img.jpg'], dryrun=False)
+    r.run()
+
+    assert _FakePopen.instances[0].args == ['exiftran', '-aip', '/x/img.jpg']
+    assert r.status()['good'] == 1
+    assert r.status()['errors'] == 0
+
+
+def test_exiftran_error_counted(cfg, monkeypatch):
+    cfg.set('main', 'use_jpegtran', '0')
+    _FakePopen.stderr_lines = ['some failure\n']
+    monkeypatch.setattr(rotator.subprocess, 'Popen', _FakePopen)
+
+    r = rotator.Rotator(cfg, ['/x/img.jpg'], dryrun=False)
+    r.run()
+
+    assert r.status()['errors'] == 1
+    assert r.status()['good'] == 0
+
+
+def test_exiftran_dryrun_skips_subprocess(cfg, monkeypatch):
+    cfg.set('main', 'use_jpegtran', '0')
+    monkeypatch.setattr(rotator.subprocess, 'Popen', _FakePopen)
+
+    r = rotator.Rotator(cfg, ['/x/img.jpg'], dryrun=True)
+    r.run()
+
+    assert not _FakePopen.instances
+    assert r.status()['good'] == 1
+
+
+# --- jpegtran path ---
+
+
+@pytest.fixture
+def jpeg_cfg(cfg, monkeypatch):
+    cfg.set('main', 'use_jpegtran', '1')
+    monkeypatch.setattr(rotator.exiftool, 'ExifToolHelper', _FakeHelper)
+    monkeypatch.setattr(rotator.subprocess, 'Popen', _FakePopen)
+    return cfg
+
+
+def test_jpegtran_builds_list_argv(tmp_path, jpeg_cfg):
+    img = tmp_path / 'img.jpg'
+    img.write_bytes(b'x')
+    _FakeHelper.orientation = 6
+
+    r = rotator.Rotator(jpeg_cfg, [str(img)], dryrun=False)
+    r.run()
+
+    args = _FakePopen.instances[0].args
+    assert isinstance(args, list)
+    assert args[:4] == ['jpegtran', '-copy', 'all', '-outfile']
+    assert args[5:] == ['-rotate', '90', str(img)]
+    assert args[4].startswith(str(tmp_path))  # temp file lives beside the source
+    assert img.exists()  # temp file renamed back into place
+    assert r.status()['good'] == 1
+
+
+@pytest.mark.parametrize(
+    'orientation,expected',
+    [
+        (2, ['-flip', 'horizontal']),
+        (3, ['-rotate', '180']),
+        (4, ['-flip', 'vertical']),
+        (5, ['-transpose']),
+        (6, ['-rotate', '90']),
+        (7, ['-transverse']),
+        (8, ['-rotate', '270']),
+    ],
+)
+def test_jpegtran_orientation_mapping(tmp_path, jpeg_cfg, orientation, expected):
+    img = tmp_path / 'img.jpg'
+    img.write_bytes(b'x')
+    _FakeHelper.orientation = orientation
+
+    rotator.Rotator(jpeg_cfg, [str(img)], dryrun=False).run()
+
+    assert _FakePopen.instances[0].args[5:] == expected + [str(img)]
+
+
+@pytest.mark.parametrize('orientation', [0, 1, None])
+def test_jpegtran_noop_orientations(tmp_path, jpeg_cfg, orientation):
+    img = tmp_path / 'img.jpg'
+    img.write_bytes(b'x')
+    _FakeHelper.orientation = orientation
+
+    r = rotator.Rotator(jpeg_cfg, [str(img)], dryrun=False)
+    r.run()
+
+    assert not _FakePopen.instances
+    assert r.status()['good'] == 1
+    assert img.read_bytes() == b'x'
+
+
+def test_jpegtran_dryrun_skips_subprocess(tmp_path, jpeg_cfg):
+    img = tmp_path / 'img.jpg'
+    img.write_bytes(b'x')
+    _FakeHelper.orientation = 6
+
+    r = rotator.Rotator(jpeg_cfg, [str(img)], dryrun=True)
+    r.run()
+
+    assert not _FakePopen.instances
+    assert r.status()['good'] == 1
+    assert img.read_bytes() == b'x'
+
+
+def test_jpegtran_failure_keeps_original(tmp_path, jpeg_cfg):
+    img = tmp_path / 'img.jpg'
+    img.write_bytes(b'x')
+    _FakeHelper.orientation = 6
+    _FakePopen.stderr_lines = ['jpegtran: bad file\n']
+
+    r = rotator.Rotator(jpeg_cfg, [str(img)], dryrun=False)
+    r.run()
+
+    assert r.status()['errors'] == 1
+    assert img.exists()

--- a/photo_importer/run.py
+++ b/photo_importer/run.py
@@ -25,7 +25,7 @@ class ProgressBar(threading.Thread):
             self.__pbar = None
 
         self.__pbar = progressbar.ProgressBar(
-            maxval=count,
+            max_value=count,
             widgets=[
                 name,
                 ' ',

--- a/photo_importer/run.py
+++ b/photo_importer/run.py
@@ -90,7 +90,7 @@ def main():
 
     status = imp.status()
     logging.info('status: %s', str(status))
-    if status['move']['errors'] != 0 or status['rotate']['errors'] != 0:
+    if status.get('move', {}).get('errors', 0) != 0 or status.get('rotate', {}).get('errors', 0) != 0:
         print('Some errors found. Please check log file.')
 
 

--- a/photo_importer/run.py
+++ b/photo_importer/run.py
@@ -25,7 +25,7 @@ class ProgressBar(threading.Thread):
             self.__pbar = None
 
         self.__pbar = progressbar.ProgressBar(
-            max_value=count,
+            maxval=count,
             widgets=[
                 name,
                 ' ',

--- a/photo_importer/run.py
+++ b/photo_importer/run.py
@@ -90,7 +90,10 @@ def main():
 
     status = imp.status()
     logging.info('status: %s', str(status))
-    if status.get('move', {}).get('errors', 0) != 0 or status.get('rotate', {}).get('errors', 0) != 0:
+    if (
+        status.get('move', {}).get('errors', 0) != 0
+        or status.get('rotate', {}).get('errors', 0) != 0
+    ):
         print('Some errors found. Please check log file.')
 
 

--- a/photo_importer/run.py
+++ b/photo_importer/run.py
@@ -90,10 +90,7 @@ def main():
 
     status = imp.status()
     logging.info('status: %s', str(status))
-    if (
-        status.get('move', {}).get('errors', 0) != 0
-        or status.get('rotate', {}).get('errors', 0) != 0
-    ):
+    if status.get('move', {}).get('errors', 0) != 0 or status.get('rotate', {}).get('errors', 0) != 0:
         print('Some errors found. Please check log file.')
 
 

--- a/photo_importer/run_test.py
+++ b/photo_importer/run_test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+# pylint: disable=redefined-outer-name,unused-argument,too-few-public-methods
+
+import sys
+
+from photo_importer import run
+
+
+def test_args_parse_full(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['prog', '/in', '/out', '-d', '-c', 'cfg.ini'])
+    args = run.args_parse()
+    assert args.in_path == '/in'
+    assert args.out_path == '/out'
+    assert args.dryrun is True
+    assert args.config == 'cfg.ini'
+
+
+def test_args_parse_optional_outpath(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['prog', '/in'])
+    args = run.args_parse()
+    assert args.in_path == '/in'
+    assert args.out_path is None
+    assert args.dryrun is False
+
+
+class _FakeImporter:
+    def __init__(self, statuses):
+        self._statuses = list(statuses)
+        self._last = self._statuses[-1]
+
+    def status(self):
+        if self._statuses:
+            return self._statuses.pop(0)
+        return self._last
+
+
+def test_progressbar_runs_through_stages(capsys):
+    statuses = [
+        {'stage': 'scan'},
+        {'stage': 'move', 'total': 2},
+        {'stage': 'move', 'total': 2, 'move': {'processed': 1}},
+        {'stage': 'rotate', 'total': 2},
+        {'stage': 'rotate', 'total': 2, 'rotate': {'processed': 2}},
+        {'stage': 'done'},
+    ]
+    run.ProgressBar(_FakeImporter(statuses)).run()
+    assert 'Found 2 files' in capsys.readouterr().out
+
+
+def test_main_on_empty_dir(tmp_path, monkeypatch, fake_exiftool):
+    indir = tmp_path / 'in'
+    indir.mkdir()
+    cfgfile = tmp_path / 'c.cfg'
+    cfgfile.write_text('[main]\nuse_jpegtran = 0\n')
+    logfile = tmp_path / 'log.txt'
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['prog', str(indir), str(tmp_path / 'out'), '-c', str(cfgfile), '-l', str(logfile)],
+    )
+
+    run.main()
+
+    assert logfile.exists()

--- a/photo_importer/server.py
+++ b/photo_importer/server.py
@@ -56,10 +56,7 @@ class PhotoImporterHandler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(bytearray(explain, 'utf-8'))
 
     def __get_mounted_list(self):
-        return {
-            os.path.basename(dp.device): (dp.device, dp.mountpoint)
-            for dp in psutil.disk_partitions()
-        }
+        return {os.path.basename(dp.device): (dp.device, dp.mountpoint) for dp in psutil.disk_partitions()}
 
     def __bytes_to_gbytes(self, b):
         return round(b / 1024.0 / 1024.0 / 1024.0, 2)
@@ -396,6 +393,7 @@ class PhotoImporterHandler(http.server.BaseHTTPRequestHandler):
 
 class PhotoImporterServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     daemon_threads = True
+
     def __init__(self, cfg):
         self.__cfg = cfg
         self.__importers = {}

--- a/photo_importer/server.py
+++ b/photo_importer/server.py
@@ -10,6 +10,7 @@ import logging
 import argparse
 import threading
 import subprocess
+import socketserver
 import http.server
 from http import HTTPStatus
 
@@ -393,7 +394,8 @@ class PhotoImporterHandler(http.server.BaseHTTPRequestHandler):
             logging.exception(ex)
 
 
-class PhotoImporterServer(http.server.HTTPServer):
+class PhotoImporterServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
     def __init__(self, cfg):
         self.__cfg = cfg
         self.__importers = {}
@@ -419,6 +421,7 @@ class PhotoImporterServer(http.server.HTTPServer):
         return self.__move_mode
 
     def import_start(self, in_path, out_path):
+        in_path = os.path.realpath(in_path)
         logging.info('import_start: %s', in_path)
 
         imp = importer.Importer(self.__cfg, in_path, out_path, False)
@@ -427,6 +430,7 @@ class PhotoImporterServer(http.server.HTTPServer):
         imp.start()
 
     def import_status(self, in_path):
+        in_path = os.path.realpath(in_path)
         with self.__importers_lock:
             imp = self.__importers.get(in_path)
         if imp is not None:
@@ -434,12 +438,14 @@ class PhotoImporterServer(http.server.HTTPServer):
         return None
 
     def import_done(self, in_path):
+        in_path = os.path.realpath(in_path)
         logging.info('import_done: %s', in_path)
         with self.__importers_lock:
             self.__importers.pop(in_path, None)
         return ''
 
     def get_log(self, in_path):
+        in_path = os.path.realpath(in_path)
         with self.__importers_lock:
             imp = self.__importers.get(in_path)
         if imp is not None:

--- a/photo_importer/server.py
+++ b/photo_importer/server.py
@@ -8,6 +8,7 @@ import json
 import urllib
 import logging
 import argparse
+import threading
 import subprocess
 import http.server
 from http import HTTPStatus
@@ -91,7 +92,7 @@ class PhotoImporterHandler(http.server.BaseHTTPRequestHandler):
 
         return res
 
-    def __get_removable_devices_win(self):
+    def __get_removable_devices_win(self):  # pragma: no cover
         import win32api
         import win32con
         import win32file
@@ -192,7 +193,6 @@ class PhotoImporterHandler(http.server.BaseHTTPRequestHandler):
 
             with subprocess.Popen(
                 cmd,
-                shell=True,
                 universal_newlines=True,
                 stderr=subprocess.PIPE,
             ) as p:
@@ -215,11 +215,11 @@ class PhotoImporterHandler(http.server.BaseHTTPRequestHandler):
 
     def __mount_mount(self, dev):
         dev_path = self.__check_dev_for_mount(dev)
-        return self.__run_cmd(f'pmount --umask=000 {dev_path}')
+        return self.__run_cmd(['pmount', '--umask=000', dev_path])
 
     def __mount_umount(self, dev):
         dev_path = self.__check_dev_for_mount(dev)
-        return self.__run_cmd(f'pumount {dev_path}')
+        return self.__run_cmd(['pumount', dev_path])
 
     def __mount_request(self, params):
         try:
@@ -309,8 +309,9 @@ class PhotoImporterHandler(http.server.BaseHTTPRequestHandler):
         try:
             if (path[0]) == '/':
                 path = path[1:]
-            fname = os.path.normpath(os.path.join(self.server.web_path(), path))
-            if not fname.startswith(self.server.web_path()):
+            web_path = self.server.web_path()
+            fname = os.path.normpath(os.path.join(web_path, path))
+            if fname != web_path and not fname.startswith(web_path + os.sep):
                 logging.warning('incorrect path: %s', path)
                 raise HTTPError(HTTPStatus.NOT_FOUND, path)
             ext = os.path.splitext(fname)[1]
@@ -318,11 +319,11 @@ class PhotoImporterHandler(http.server.BaseHTTPRequestHandler):
             if ext == '.html':
                 cont = 'text/html'
             elif ext == '.js':
-                cont = 'text/script'
+                cont = 'application/javascript'
             elif ext == '.png':
                 cont = 'image/png'
             else:
-                cont = 'text/none'
+                cont = 'application/octet-stream'
             with open(fname, 'rb') as f:  # lgtm[py/path-injection]
                 self.send_response(200)
                 self.send_header('Content-type', cont)
@@ -382,6 +383,9 @@ class PhotoImporterHandler(http.server.BaseHTTPRequestHandler):
             if path == '/import':
                 self.__import_request(params)
                 return
+
+            logging.warning('Wrong path: %s', path)
+            raise HTTPError(HTTPStatus.NOT_FOUND, path)
         except HTTPError as ex:
             self.__error_response_post(ex.code, ex.reason)
         except Exception as ex:
@@ -393,12 +397,14 @@ class PhotoImporterServer(http.server.HTTPServer):
     def __init__(self, cfg):
         self.__cfg = cfg
         self.__importers = {}
+        self.__importers_lock = threading.Lock()
+        host = cfg['server']['host']
         port = int(cfg['server']['port'])
         self.__web_path = os.path.normpath(cfg['server']['web_path'])
         self.__out_path = cfg['server']['out_path']
         self.__fixed_in_path = cfg['server']['in_path']
         self.__move_mode = int(cfg['main']['move_mode'])
-        super().__init__(('', port), PhotoImporterHandler)
+        super().__init__((host, port), PhotoImporterHandler)
 
     def web_path(self):
         return self.__web_path
@@ -415,24 +421,29 @@ class PhotoImporterServer(http.server.HTTPServer):
     def import_start(self, in_path, out_path):
         logging.info('import_start: %s', in_path)
 
-        self.__importers[in_path] = importer.Importer(self.__cfg, in_path, out_path, False)
-
-        self.__importers[in_path].start()
+        imp = importer.Importer(self.__cfg, in_path, out_path, False)
+        with self.__importers_lock:
+            self.__importers[in_path] = imp
+        imp.start()
 
     def import_status(self, in_path):
-        if in_path in self.__importers:
-            return self.__importers[in_path].status()
+        with self.__importers_lock:
+            imp = self.__importers.get(in_path)
+        if imp is not None:
+            return imp.status()
         return None
 
     def import_done(self, in_path):
         logging.info('import_done: %s', in_path)
-        if in_path in self.__importers:
-            del self.__importers[in_path]
+        with self.__importers_lock:
+            self.__importers.pop(in_path, None)
         return ''
 
     def get_log(self, in_path):
-        if in_path in self.__importers:
-            return self.__importers[in_path].log_text()
+        with self.__importers_lock:
+            imp = self.__importers.get(in_path)
+        if imp is not None:
+            return imp.log_text()
         return ''
 
 

--- a/photo_importer/server_test.py
+++ b/photo_importer/server_test.py
@@ -1,0 +1,346 @@
+#!/usr/bin/python3
+# pylint: disable=redefined-outer-name,unused-argument,too-few-public-methods
+
+import sys
+import json
+import http.client
+import threading
+
+import pytest
+
+from photo_importer import server
+
+
+class _Stream:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def readline(self):
+        return self._lines.pop(0) if self._lines else ''
+
+
+class _RecPopen:
+    calls = []
+
+    def __init__(self, args, **kwargs):
+        _RecPopen.calls.append(args)
+        self.stderr = _Stream([])
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class _ErrPopen:
+    def __init__(self, args, **kwargs):
+        self.stderr = _Stream(['mount error\n'])
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+_DEVICES_ATTR = '_PhotoImporterHandler__get_removable_devices'
+
+
+@pytest.fixture
+def http_server(tmp_path, cfg, fake_exiftool, monkeypatch):
+    web = tmp_path / 'web'
+    web.mkdir()
+    (web / 'index.html').write_text('<html>hello</html>')
+    (web / 'app.js').write_text('console.log(1)')
+    cfg.set('server', 'web_path', str(web))
+    cfg.set('server', 'host', '127.0.0.1')
+    cfg.set('server', 'port', '0')
+    monkeypatch.setattr(server.PhotoImporterHandler, 'log_message', lambda *a, **k: None)
+
+    srv = server.PhotoImporterServer(cfg)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield srv.server_port
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        thread.join()
+
+
+def _request(port, method, path):
+    conn = http.client.HTTPConnection('127.0.0.1', port)
+    try:
+        conn.request(method, path)
+        resp = conn.getresponse()
+        body = resp.read()
+        return resp.status, resp.getheader('Content-type'), body
+    finally:
+        conn.close()
+
+
+def test_index_served(http_server):
+    status, ctype, body = _request(http_server, 'GET', '/')
+    assert status == 200
+    assert ctype == 'text/html'
+    assert b'hello' in body
+
+
+def test_js_content_type(http_server):
+    status, ctype, _ = _request(http_server, 'GET', '/app.js')
+    assert status == 200
+    assert ctype == 'application/javascript'
+
+
+def test_missing_file_404(http_server):
+    status, _, _ = _request(http_server, 'GET', '/nope.html')
+    assert status == 404
+
+
+def test_path_traversal_blocked(http_server, tmp_path):
+    (tmp_path / 'secret.html').write_text('secret')
+    status, _, _ = _request(http_server, 'GET', '/../secret.html')
+    assert status == 404
+
+
+def test_unknown_get_path_404(http_server):
+    status, _, _ = _request(http_server, 'GET', '/bogus')
+    assert status == 404
+
+
+def test_unknown_post_path_404(http_server):
+    status, _, _ = _request(http_server, 'POST', '/bogus')
+    assert status == 404
+
+
+def test_sysinfo(http_server, tmp_path):
+    status, _, body = _request(http_server, 'GET', '/sysinfo?p=' + str(tmp_path))
+    assert status == 200
+    data = json.loads(body)
+    assert {'disk_size', 'disk_usage', 'cpu', 'mem_total', 'mem_usage'} <= set(data)
+
+
+def test_mount_list_empty(http_server, monkeypatch):
+    monkeypatch.setattr(server.PhotoImporterHandler, _DEVICES_ATTR, lambda self: {})
+    status, _, body = _request(http_server, 'GET', '/mount?a=list')
+    assert status == 200
+    assert json.loads(body) == {}
+
+
+def test_mount_unknown_action_400(http_server):
+    status, _, _ = _request(http_server, 'GET', '/mount?a=frobnicate')
+    assert status == 400
+
+
+def test_mount_mount_uses_argv_list(http_server, monkeypatch):
+    _RecPopen.calls = []
+    monkeypatch.setattr(
+        server.PhotoImporterHandler,
+        _DEVICES_ATTR,
+        lambda self: {'sdz1': {'dev_path': '/dev/sdz1', 'mount_path': '', 'read_only': False}},
+    )
+    monkeypatch.setattr(server.subprocess, 'Popen', _RecPopen)
+
+    status, _, _ = _request(http_server, 'POST', '/mount?a=mount&d=sdz1')
+
+    assert status == 200
+    assert _RecPopen.calls == [['pmount', '--umask=000', '/dev/sdz1']]
+
+
+def test_mount_unknown_device_400(http_server, monkeypatch):
+    monkeypatch.setattr(server.PhotoImporterHandler, _DEVICES_ATTR, lambda self: {})
+    status, _, _ = _request(http_server, 'POST', '/mount?a=mount&d=sdz1')
+    assert status == 400
+
+
+def test_mount_list_with_devices(http_server, tmp_path, monkeypatch):
+    mnt = tmp_path / 'mnt'
+    mnt.mkdir()
+    (mnt / 'f.bin').write_bytes(b'x' * 10)
+    devices = {
+        'sdz1': {'dev_path': '/dev/sdz1', 'mount_path': str(mnt), 'read_only': False},
+        server.FIXED_IN_PATH_NAME: {
+            'dev_path': server.FIXED_IN_PATH_NAME,
+            'mount_path': str(mnt),
+            'read_only': False,
+        },
+    }
+    monkeypatch.setattr(server.PhotoImporterHandler, _DEVICES_ATTR, lambda self: devices)
+
+    status, _, body = _request(http_server, 'GET', '/mount?a=list')
+
+    assert status == 200
+    data = json.loads(body)
+    assert set(data) == {'sdz1', server.FIXED_IN_PATH_NAME}
+    assert data['sdz1']['state'] == 'mounted'
+
+
+def test_mount_cmd_error_500(http_server, monkeypatch):
+    monkeypatch.setattr(
+        server.PhotoImporterHandler,
+        _DEVICES_ATTR,
+        lambda self: {'sdz1': {'dev_path': '/dev/sdz1', 'mount_path': '', 'read_only': False}},
+    )
+    monkeypatch.setattr(server.subprocess, 'Popen', _ErrPopen)
+
+    status, _, _ = _request(http_server, 'POST', '/mount?a=umount&d=sdz1')
+
+    assert status == 500
+
+
+# --- import requests over HTTP ---
+
+
+def test_import_start_over_http(http_server, tmp_path):
+    indir = tmp_path / 'imp_in'
+    indir.mkdir()
+    status, _, body = _request(
+        http_server, 'POST', f'/import?a=start&p={indir}&o={tmp_path / "imp_out"}'
+    )
+    assert status == 200
+    assert json.loads(body) is True
+
+
+def test_import_getlog_over_http(http_server, tmp_path):
+    indir = tmp_path / 'imp_log'
+    indir.mkdir()
+    _request(http_server, 'POST', f'/import?a=start&p={indir}&o={tmp_path / "o"}')
+    status, ctype, _ = _request(http_server, 'GET', f'/import?a=getlog&p={indir}')
+    assert status == 200
+    assert ctype == 'text/plain'
+
+
+def test_import_done_over_http(http_server, tmp_path):
+    indir = tmp_path / 'imp_done'
+    indir.mkdir()
+    _request(http_server, 'POST', f'/import?a=start&p={indir}&o={tmp_path / "o"}')
+    status, _, _ = _request(http_server, 'POST', f'/import?a=done&p={indir}')
+    assert status == 200
+
+
+def test_import_stop_not_implemented(http_server):
+    status, _, body = _request(http_server, 'GET', '/import?a=stop&p=/x')
+    assert status == 200
+    assert json.loads(body) is False
+
+
+def test_import_missing_param_400(http_server):
+    status, _, _ = _request(http_server, 'GET', '/import?a=start')
+    assert status == 400
+
+
+def test_import_unknown_action_400(http_server):
+    status, _, _ = _request(http_server, 'GET', '/import?a=foo&p=/x')
+    assert status == 400
+
+
+# --- mount list reflecting import status ---
+
+
+def _device(mnt):
+    return {'sdz1': {'dev_path': '/dev/sdz1', 'mount_path': str(mnt), 'read_only': False}}
+
+
+def test_mount_list_import_progress(http_server, tmp_path, monkeypatch):
+    mnt = tmp_path / 'm'
+    mnt.mkdir()
+    monkeypatch.setattr(server.PhotoImporterHandler, _DEVICES_ATTR, lambda self: _device(mnt))
+    monkeypatch.setattr(
+        server.PhotoImporterServer,
+        'import_status',
+        lambda self, p: {'stage': 'move', 'total': 10, 'move': {'processed': 5}},
+    )
+
+    status, _, body = _request(http_server, 'GET', '/mount?a=list')
+
+    assert status == 200
+    data = json.loads(body)
+    assert data['sdz1']['state'] == 'move'
+    assert data['sdz1']['progress'] == 50
+
+
+def test_mount_list_import_done_with_errors(http_server, tmp_path, monkeypatch):
+    mnt = tmp_path / 'm2'
+    mnt.mkdir()
+    monkeypatch.setattr(server.PhotoImporterHandler, _DEVICES_ATTR, lambda self: _device(mnt))
+    monkeypatch.setattr(
+        server.PhotoImporterServer,
+        'import_status',
+        lambda self, p: {
+            'stage': 'done',
+            'total': 3,
+            'move': {'errors': 1},
+            'rotate': {'errors': 0},
+        },
+    )
+
+    status, _, body = _request(http_server, 'GET', '/mount?a=list')
+
+    assert status == 200
+    assert json.loads(body)['sdz1']['state'] == 'error'
+
+
+def test_mount_list_import_done_ok(http_server, tmp_path, monkeypatch):
+    mnt = tmp_path / 'm3'
+    mnt.mkdir()
+    monkeypatch.setattr(server.PhotoImporterHandler, _DEVICES_ATTR, lambda self: _device(mnt))
+    monkeypatch.setattr(
+        server.PhotoImporterServer,
+        'import_status',
+        lambda self, p: {
+            'stage': 'done',
+            'total': 3,
+            'move': {'errors': 0},
+            'rotate': {'errors': 0},
+        },
+    )
+
+    status, _, body = _request(http_server, 'GET', '/mount?a=list')
+
+    assert status == 200
+    data = json.loads(body)['sdz1']
+    assert data['state'] == 'done'
+    assert data['total'] == 3
+
+
+# --- main() ---
+
+
+def test_main_handles_keyboard_interrupt(tmp_path, monkeypatch):
+    cfgfile = tmp_path / 'c.cfg'
+    cfgfile.write_text(f'[server]\nlog_file = {tmp_path / "s.log"}\n')
+
+    closed = []
+
+    class _FakeServer:
+        def __init__(self, cfg):
+            self.socket = type('S', (), {'close': lambda s: closed.append(True)})()
+
+        def serve_forever(self):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(server, 'PhotoImporterServer', _FakeServer)
+    monkeypatch.setattr(sys, 'argv', ['prog', '-c', str(cfgfile)])
+
+    server.main()
+
+    assert closed == [True]
+
+
+def test_import_lifecycle(tmp_path, cfg, fake_exiftool):
+    indir = tmp_path / 'in'
+    indir.mkdir()
+    cfg.set('server', 'host', '127.0.0.1')
+    cfg.set('server', 'port', '0')
+
+    srv = server.PhotoImporterServer(cfg)
+    try:
+        assert srv.import_status(str(indir)) is None
+        srv.import_start(str(indir), str(tmp_path / 'out'))
+        assert srv.import_status(str(indir)) is not None
+        assert srv.get_log(str(indir)) != ''
+        assert srv.import_done(str(indir)) == ''
+        assert srv.import_status(str(indir)) is None
+    finally:
+        srv.server_close()

--- a/photo_importer/server_test.py
+++ b/photo_importer/server_test.py
@@ -195,9 +195,7 @@ def test_mount_cmd_error_500(http_server, monkeypatch):
 def test_import_start_over_http(http_server, tmp_path):
     indir = tmp_path / 'imp_in'
     indir.mkdir()
-    status, _, body = _request(
-        http_server, 'POST', f'/import?a=start&p={indir}&o={tmp_path / "imp_out"}'
-    )
+    status, _, body = _request(http_server, 'POST', f'/import?a=start&p={indir}&o={tmp_path / "imp_out"}')
     assert status == 200
     assert json.loads(body) is True
 

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
     <div>
-        <div class="table table-striped table-bordered" id="devTable"/>
+        <div class="table table-striped table-bordered" id="devTable"></div>
     </div>
     <div id="storagePath"></div>
     <br/>
@@ -23,20 +23,36 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
     <script type="text/javascript">
         var g_outpath;
+        var updateTimer;
+        var sysInfoTimer;
+
+        function escapeHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function clamp(n) {
+            return Math.min(100, Math.max(0, Number(n) || 0));
+        }
 
         function progress(p, caption, style)
-        {            
+        {
+            const pct = clamp(p);
             return "<div class=\"progress\">"
-                 + "<p class=\"text-monospace\">" + caption + "</p>"
-                 + "<div class=\"progress-bar " + style + "\" role=\"progressbar\" style=\"width: " + p + "%;\" aria-valuenow=\"" + p + "\" aria-valuemin=\"0\" aria-valuemax=\"100\">" 
-                 + p + "%</div>"
+                 + "<p class=\"text-monospace\">" + escapeHtml(caption) + "</p>"
+                 + "<div class=\"progress-bar " + style + "\" role=\"progressbar\" style=\"width: " + pct + "%;\" aria-valuenow=\"" + pct + "\" aria-valuemin=\"0\" aria-valuemax=\"100\">"
+                 + pct + "%</div>"
                  + "</div>"
         }
 
         function setMountList(data)
         {
-            var html = "<table>"
-            html += "<tr>" 
+            let html = "<table>"
+            html += "<tr>"
                  + "<th>Device</th>"
                  + "<th>Mount&nbsp;point</th>"
                  + "<th>Status</th>"
@@ -45,53 +61,53 @@
                  + "<th>Usage</th>"
                  + "<th>Log</th>"
                  + "</tr>"
-            for (var dev in data) {
-                var action = ""
-                var state = data[dev].state
-                var name = dev
-                var path = encodeURIComponent(data[dev].path)
+            for (const dev of Object.keys(data)) {
+                let action = ""
+                const state = data[dev].state
+                let name = dev
+                const path = encodeURIComponent(data[dev].path)
                 if (dev.startsWith("none")) {
                     name = ""
-                    if (state == "mounted" || state == "done") {
+                    if (state == "mounted") {
                         action += "<input onclick=\"sendCommand('start', '" + path + "');\" type=button class=\"btn btn-success btn-sm\" value=\"Import\"/> ";
                     } else if (state == "done" || state == "error") {
                         action = "<input onclick=\"sendCommand('done', '" + path + "');\" type=button class=\"btn btn-primary btn-sm\" value=\"Clear\"/> ";
                     }
                 } else {
                     if (state == "mounted") {
-                        action += "<input onclick=\"sendCommand('umount', '" + dev + "');\" type=button class=\"btn btn-primary btn-sm\" value=\"Unmount\"/> ";
+                        action += "<input onclick=\"sendCommand('umount', '" + encodeURIComponent(dev) + "');\" type=button class=\"btn btn-primary btn-sm\" value=\"Unmount\"/> ";
                         if (data[dev].allow_start) {
                             action += "<input onclick=\"sendCommand('start', '" + path + "');\" type=button class=\"btn btn-success btn-sm\" value=\"Import\"/> ";
                         }
                     } else if (state == "unmounted") {
-                        action = "<input onclick=\"sendCommand('mount', '" + dev + "');\" type=button class=\"btn btn-primary btn-sm\" value=\"Mount\"/> ";
+                        action = "<input onclick=\"sendCommand('mount', '" + encodeURIComponent(dev) + "');\" type=button class=\"btn btn-primary btn-sm\" value=\"Mount\"/> ";
                     } else if (state == "done" || state == "error") {
-                        action = "<input onclick=\"sendCommand('umount', '" + dev + "');\" type=button class=\"btn btn-primary btn-sm\" value=\"Unmount\"/> ";
+                        action = "<input onclick=\"sendCommand('umount', '" + encodeURIComponent(dev) + "');\" type=button class=\"btn btn-primary btn-sm\" value=\"Unmount\"/> ";
                     }
                 }
-                var stat = state 
-                var p = data[dev].progress
+                let stat = escapeHtml(state)
+                const p = data[dev].progress
                 if (p != 0) {
                     stat += progress(p, "", "")
                 }
                 if (state == "done") {
-                    stat += "<br/><font size=\"-1\">(total: " + data[dev].total + ")<font>"
+                    stat += "<br/><small>(total: " + escapeHtml(String(data[dev].total)) + ")</small>"
                 } else if (state == "error") {
-                    stat += "<br/><font size=\"-2\">(" + data[dev].details + ")<font>"
+                    stat += "<br/><small>(" + escapeHtml(String(data[dev].details)) + ")</small>"
                 }
                 if (data[dev].read_only) {
-                    name += "<br/><font size=\"-2\">(read only)<font>"
+                    name += "<br/><small>(read only)</small>"
                 }
-                var log = ""
+                let log = ""
                 if (path != "") {
-                    log = "<a href=\"import?a=getlog&p=" + path + "\"><img src=\"log.png\"/></a>"	
+                    log = "<a href=\"import?a=getlog&p=" + path + "\"><img src=\"log.png\"/></a>"
                 }
                 html += "<tr>"
-                     + "<td>" + name + "</td>"
-                     + "<td>" + data[dev].path + "</td>"
+                     + "<td>" + escapeHtml(name) + "</td>"
+                     + "<td>" + escapeHtml(data[dev].path) + "</td>"
                      + "<td>" + stat + "</td>"
                      + "<td>" + action + "</td>"
-                     + "<td>" + data[dev].size + "&nbsp;GB</td>"
+                     + "<td>" + escapeHtml(String(data[dev].size)) + "&nbsp;GB</td>"
                      + "<td>" + progress(data[dev].usage, "", "bg-info") + "</td>"
                      + "<td>" + log + "</td>"
                      + "</tr>"
@@ -102,7 +118,7 @@
 
         function setSysInfo(data)
         {
-            var html = ""
+            let html = ""
             html += progress(data.cpu, "CPU: ", "bg-danger")
             html += progress(data.mem_usage, "MEM: ", "bg-warning")
             html += progress(data.disk_usage, "HDD: ", "bg-info")
@@ -111,41 +127,42 @@
 
         function update()
         {
-            $.ajax({  
+            $.ajax({
                 url: "mount?a=list",
-                cache: false,  
-                success: function(json) {  
-                    var data = eval(json);
-                    
+                cache: false,
+                dataType: "json",
+                success: function(data) {
                     setMountList(data);
-                }  
+                },
+                error: function(request, status, error) {
+                    console.error('Failed to fetch device list:', status, error);
+                }
             });
         }
-        
+
         function updateSysInfo()
         {
-            var argpath = "";
-            if (g_outpath) {
-                argpath = "?p=" + g_outpath;
-            }
-            $.ajax({  
+            const argpath = g_outpath ? "?p=" + encodeURIComponent(g_outpath) : "";
+            $.ajax({
                 url: "sysinfo" + argpath,
-                cache: false,  
-                success: function(json) {  
-                    var data = eval(json);
-                    
+                cache: false,
+                dataType: "json",
+                success: function(data) {
                     setSysInfo(data);
-                }  
+                },
+                error: function(request, status, error) {
+                    console.error('Failed to fetch system info:', status, error);
+                }
             });
         }
-        
+
         function sendCommand(cmd, dev)
         {
-            if (cmd == "mount" || cmd == "umount") { 
+            if (cmd == "mount" || cmd == "umount") {
                 $.ajax({
                     url: "mount?a=" + cmd + "&d=" + dev,
                     type: "POST",
-                    success: function() {  
+                    success: function() {
                         update()
                     },
                     error: function (request, status, error) {
@@ -153,15 +170,12 @@
                     }
                 });
             } else
-            if (cmd == "start" || cmd == "done") { 
-                var argpath = "";
-                if (g_outpath) {
-                    argpath = "&o=" + g_outpath;
-                }
+            if (cmd == "start" || cmd == "done") {
+                const argpath = g_outpath ? "&o=" + encodeURIComponent(g_outpath) : "";
                 $.ajax({
                     url: "import?a=" + cmd + "&p=" + dev + argpath,
                     type: "POST",
-                    success: function() {  
+                    success: function() {
                         update()
                     },
                     error: function (request, status, error) {
@@ -170,10 +184,22 @@
                 });
             }
         }
-         
+
+        function startTimers()
+        {
+            updateTimer = setInterval(update, 5000);
+            sysInfoTimer = setInterval(updateSysInfo, 1000);
+        }
+
+        function stopTimers()
+        {
+            clearInterval(updateTimer);
+            clearInterval(sysInfoTimer);
+        }
+
         function init()
         {
-            var urlParams = new URLSearchParams(window.location.search);
+            const urlParams = new URLSearchParams(window.location.search);
             g_outpath = urlParams.get('outpath');
 
             if (g_outpath) {
@@ -186,15 +212,24 @@
 
         function reload()
         {
-            location.reload(true)
+            location.reload()
         }
 
-        $(document).ready(function() 
+        $(document).ready(function()
         {
             init();
-            setInterval(update, 5000);  
-            setInterval(updateSysInfo, 1000);  
-            setInterval(reload, 3600000); //reload page every hour
+            startTimers();
+            setInterval(reload, 3600000);
+
+            document.addEventListener('visibilitychange', function() {
+                if (document.hidden) {
+                    stopTimers();
+                } else {
+                    update();
+                    updateSysInfo();
+                    startTimers();
+                }
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
  * Fix jpegtran rotator returncode check (was always None before p.wait())
  * Fix empty directory cleanup ordering
  * Fix dryrun mode for file skipping
  * Fix server security: validate and sanitize input paths
  * Add ThreadingMixIn to HTTP server for concurrent request handling
  * Add explicit MemLogger.close() to prevent log handler leakage
  * Add exist_ok=True to os.makedirs() to prevent race on concurrent imports
  * Guard missing move/rotate status keys in CLI error reporting
  * Guard empty directory part in log file path creation
  * Add os.path.realpath() normalization for importer path keys in server
  * Update deprecated progressbar maxval field
  * Add Config use_system_config parameter for test isolation
  * Improve web UI: fix XSS via eval(), add escapeHtml(), fix dead state branch,
    replace <font> tags, add AJAX error handlers, add visibility-aware polling,
    add encodeURIComponent for all query params
  * Add ESLint CI workflow for JavaScript linting
  * Improve test coverage: add tests for config, mover, rotator, server, run
  * Update CI workflows: update actions/checkout, fix Python version matrix
  * Update README
  